### PR TITLE
prettier and navigation

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,4 +4,5 @@ module.exports = {
     bracketSpacing: false,
     singleQuote: true,
     trailingComma: 'all',
+    tabWidth: 2,
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
 import {NativeRouter, Route, Routes} from 'react-router-native';
 import MenuScreen from './screens/MenuScreen';
+import NotesScreen from './screens/NotesScreen';
 
 export default function App() {
   return (
     <NativeRouter>
       <Routes>
         <Route path="/" element={<MenuScreen />} />
+        <Route path="/notes" element={<NotesScreen />} />
       </Routes>
     </NativeRouter>
   );

--- a/src/hooks/useBackAction.tsx
+++ b/src/hooks/useBackAction.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react';
+import { Alert, BackHandler } from 'react-native';
+
+function useBackAction(action: () => void) {
+  return useEffect(() => {
+    const backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => {
+        action();
+        return true;
+      },
+    );
+
+    return () => backHandler.remove();
+  }, []);
+}
+
+function closeApp() {
+  return backAlert("close the app", () => BackHandler.exitApp());
+}
+
+function backAlert(description: string, onPress: () => void) {
+  console.warn("backAlert is untested")
+  Alert.alert('Hold on!', `Are you sure you want to ${description}?`, [
+    {
+      text: 'Cancel',
+      onPress: () => null,
+      style: 'cancel',
+    },
+    {text: 'YES', onPress: () => onPress()},
+  ]);
+}
+
+export { useBackAction, closeApp, backAlert };

--- a/src/screens/MenuScreen.tsx
+++ b/src/screens/MenuScreen.tsx
@@ -5,19 +5,25 @@ import {
   StyleSheet,
   TouchableHighlight,
 } from 'react-native';
+import React from 'react';
+import {useNavigate} from 'react-router-native';
 
 const image = {
   uri: 'https://wallpapers.com/images/high/pink-hearts-background-2nmnoa3disyli8si.webp',
 };
 
 export default function MenuScreen() {
+  const navigate = useNavigate(); // hook do nawigacji
+
   return (
     <ImageBackground source={image} resizeMode="cover" style={stylesImg.image}>
       <View style={styles.container}>
         <Text style={styles.text}>Hejeczka :***xoxo</Text>
+
         <TouchableHighlight
           style={styles.button}
-          onPress={() => console.log('Pressed')}>
+          onPress={() => navigate('/notes', {})}>
+          {/* nawigacja do '/notes' które zostało zarejestrowane w App.tsx */}
           <View style={styles.button}>
             <Text style={styles.buttonText}>NOTATECZKI</Text>
           </View>

--- a/src/screens/NotesScreen.tsx
+++ b/src/screens/NotesScreen.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {View, Text, StyleSheet} from 'react-native';
+import {useBackAction} from '../hooks/useBackAction';
+import {useNavigate} from 'react-router-native';
+
+export default function NotesScreen() {
+  const navigate = useNavigate();
+  useBackAction(() => navigate('/', {})); // hook do obsługi przycisku back
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>NotesScreen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: 'black',
+    fontSize: 35,
+    lineHeight: 84,
+    textAlign: 'center',
+  },
+  button: {
+    height: 100,
+    width: 200,
+    backgroundColor: '#808080c0',
+    justifyContent: 'center', // Wyśrodkowanie tekstu w pionie
+    alignItems: 'center', // Wyśrodkowanie tekstu w poziomie
+    borderRadius: 10, // Zaokrąglenie rogów przycisku
+    marginVertical: 10,
+  },
+  buttonText: {
+    color: 'pink',
+    fontSize: 30,
+  },
+});
+
+const stylesImg = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  image: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+});


### PR DESCRIPTION
Added 
- prettier for unified code style (indentation, imports etc):
- useNavigate hook for jumping to different routes registered in App.tsx
- custom useBackNavigation for listening to back button event. So when You are in Notateczki (`/notes`) and click undo button You return to menu (`'/'`) page

[Hooks tutorial](https://www.youtube.com/watch?v=TNhaISOUy6Q&ab_channel=Fireship)